### PR TITLE
Revert "Bump elf4j from 2.0.4 to 2.0.5 (#8)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.github.elf4j</groupId>
             <artifactId>elf4j</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.tinylog</groupId>


### PR DESCRIPTION
This reverts commit 19672557aa3dcc09aa8addb8b228213b7deb823f.